### PR TITLE
fix(postgres): missing database

### DIFF
--- a/humanitec-resource-defs/postgres/basic/main.tf
+++ b/humanitec-resource-defs/postgres/basic/main.tf
@@ -57,6 +57,8 @@ statefulset.yaml:
                     secretKeyRef:
                       name: {{ .init.name }}
                       key: POSTGRES_PASSWORD
+                - name: POSTGRES_DB
+                  value: {{ .init.database | quote }}
                 - name: PGDATA
                   value: /var/lib/postgresql/data/pgdata
                 - name: PGPORT


### PR DESCRIPTION
We are returning a random database name here https://github.com/humanitec-architecture/resource-packs-in-cluster/blob/main/humanitec-resource-defs/postgres/basic/main.tf#L26, but don't actually create this database.

Set `POSTGRES_DB` (docs https://hub.docker.com/_/postgres/), so this database is actually created.