### PR TITLE
Reducing max length of postgres basic name to 43

### DIFF
--- a/humanitec-resource-defs/mysql/basic/README.md
+++ b/humanitec-resource-defs/mysql/basic/README.md
@@ -23,7 +23,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | prefix | Prefix for all resources | `string` | n/a | yes |
-| name | Name of the statefulset | `string` | `"mysql-{{ \"${context.res.id}\" | replace \".\" \"-\" | substr 0 55 }}\n"` | no |
+| name | Name of the statefulset | `string` | `"mysql-{{ \"${context.res.id}\" | replace \".\" \"-\" | substr 0 46 }}\n"` | no |
 
 ## Outputs
 

--- a/humanitec-resource-defs/mysql/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/mysql/basic/terraform.tfvars.example
@@ -1,6 +1,6 @@
 
 # Name of the statefulset
-name = "mysql-{{ \"${context.res.id}\" | replace \".\" \"-\" | substr 0 55 }}\n"
+name = "mysql-{{ \"${context.res.id}\" | replace \".\" \"-\" | substr 0 46 }}\n"
 
 # Prefix for all resources
 prefix = ""

--- a/humanitec-resource-defs/mysql/basic/variables.tf
+++ b/humanitec-resource-defs/mysql/basic/variables.tf
@@ -7,9 +7,9 @@ variable "name" {
   description = "Name of the statefulset"
   type        = string
 
-  # Pods names are limited to 63 characters (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names)
-  # 63 - 6 (prefix) - 2 (suffix) = 55
+  # StatefulSets names are limited to 52 chars https://github.com/kubernetes/kubernetes/issues/64023
+  # 52 - 6 (prefix) = 46
   default = <<EOT
-mysql-{{ "$${context.res.id}" | replace "." "-" | substr 0 55 }}
+mysql-{{ "$${context.res.id}" | replace "." "-" | substr 0 46 }}
 EOT
 }

--- a/humanitec-resource-defs/postgres/basic/README.md
+++ b/humanitec-resource-defs/postgres/basic/README.md
@@ -23,7 +23,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | prefix | Prefix for all resources | `string` | n/a | yes |
-| name | Name of the statefulset | `string` | `"postgres-{{ \"${context.res.id}\" | replace \".\" \"-\" | substr 0 52 }}\n"` | no |
+| name | Name of the statefulset | `string` | `"postgres-{{ \"${context.res.id}\" | replace \".\" \"-\" | substr 0 43 }}\n"` | no |
 
 ## Outputs
 

--- a/humanitec-resource-defs/postgres/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/postgres/basic/terraform.tfvars.example
@@ -1,6 +1,6 @@
 
 # Name of the statefulset
-name = "postgres-{{ \"${context.res.id}\" | replace \".\" \"-\" | substr 0 52 }}\n"
+name = "postgres-{{ \"${context.res.id}\" | replace \".\" \"-\" | substr 0 43 }}\n"
 
 # Prefix for all resources
 prefix = ""

--- a/humanitec-resource-defs/postgres/basic/variables.tf
+++ b/humanitec-resource-defs/postgres/basic/variables.tf
@@ -10,6 +10,6 @@ variable "name" {
   # Pods names are limited to 63 characters (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names)
   # 63 - 9 (prefix) - 2 (suffix) = 52
   default = <<EOT
-postgres-{{ "$${context.res.id}" | replace "." "-" | substr 0 52 }}
+postgres-{{ "$${context.res.id}" | replace "." "-" | substr 0 43 }}
 EOT
 }

--- a/humanitec-resource-defs/postgres/basic/variables.tf
+++ b/humanitec-resource-defs/postgres/basic/variables.tf
@@ -7,8 +7,8 @@ variable "name" {
   description = "Name of the statefulset"
   type        = string
 
-  # Pods names are limited to 63 characters (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names)
-  # 63 - 9 (prefix) - 2 (suffix) = 52
+  # StatefulSets names are limited to 52 chars https://github.com/kubernetes/kubernetes/issues/64023
+  # 52 - 9 (prefix) = 43
   default = <<EOT
 postgres-{{ "$${context.res.id}" | replace "." "-" | substr 0 43 }}
 EOT


### PR DESCRIPTION
The max length of the postgres/basic Pod name needs to be reduced further so that the resulting Pod label `controller-revision-hash` has a maximum of 63 characters.

Tested with this Score file using an in-cluster Postgres as a resource using the Resource Pack...

```
apiVersion: score.dev/v1b1
metadata:
  name: hello-world-abcdefghijk
containers:
  hello-world-1234567890:
    image: postgres:alpine
    command: ["/bin/sh"]
    args: ["-c", "sleep 5; while psql $$CONNECTION_STRING -c \"SELECT version()\"; do echo Hey, connecting to DB at $${HOST} was successful!; sleep 10; done"]
    variables:
      CONNECTION_STRING: postgresql://${resources.my-postgres-db.username}:${resources.my-postgres-db.password}@${resources.my-postgres-db.host}:${resources.my-postgres-db.port}/${resources.my-postgres-db.name}
      HOST: ${resources.my-postgres-db.host}
resources:
  my-postgres-db:
    type: postgres
```

... results in this Pod. Note the length of 63 characters for the `controller-revision-hash` label:

```
apiVersion: v1
kind: Pod
metadata:
  generateName: postgres-modules-hello-world-abcdefghijk-externals-m-
  labels:
    app: postgres-modules-hello-world-abcdefghijk-externals-m
    apps.kubernetes.io/pod-index: "0"
    controller-revision-hash: postgres-modules-hello-world-abcdefghijk-externals-m-6b887484fd
    statefulset.kubernetes.io/pod-name: postgres-modules-hello-world-abcdefghijk-externals-m-0
  name: postgres-modules-hello-world-abcdefghijk-externals-m-0
```
