### PR TITLE
fix: move secret outputs to values

### DIFF
--- a/humanitec-resource-defs/mysql/basic/main.tf
+++ b/humanitec-resource-defs/mysql/basic/main.tf
@@ -113,11 +113,7 @@ host: {{ .init.name }}
 port: {{ .init.port }}
 name: {{ .init.database }}
 EOL
-      }
-    })
-    secrets_string = jsonencode({
-      templates = {
-        outputs = <<EOL
+        secrets   = <<EOL
 username: {{ .init.user }}
 password: {{ .init.password }}
 EOL

--- a/humanitec-resource-defs/postgres/basic/main.tf
+++ b/humanitec-resource-defs/postgres/basic/main.tf
@@ -107,11 +107,7 @@ host: {{ .init.name }}
 port: {{ .init.port }}
 name: {{ .init.database }}
 EOL
-      }
-    })
-    secrets_string = jsonencode({
-      templates = {
-        outputs = <<EOL
+        secrets   = <<EOL
 username: {{ .init.user }}
 password: {{ .init.password }}
 EOL


### PR DESCRIPTION
This allow to save resource definition without access to the secret store and doesn't make a difference in this case as the secrets are generated inside the template.