### PR TITLE
`redis` - Update main.tf - Fix unsupported serviceName field

### DIFF
--- a/humanitec-resource-defs/redis/basic/main.tf
+++ b/humanitec-resource-defs/redis/basic/main.tf
@@ -27,7 +27,6 @@ deployment.yaml:
     metadata:
       name: {{ .init.name }}
     spec:
-      serviceName: redis
       replicas: 1
       selector:
         matchLabels:


### PR DESCRIPTION
`serviceName` is not for `Deployment`, but for `StatefulSet`, otherwise we get this error:
```
rror provisioning resource redis#modules.test.externals.test GuResID: df3230ecb98d9109c343ac31917041f583eed380. Status: False. Reason: ApplyConfigurationError. Message: applying object redis of the kind Deployment: failed to create typed patch object (test-development/redis; apps/v1, Kind=Deployment): .spec.serviceName: field not declared in schema
```