### PR TITLE
Remove App creation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+	"name": "Score & Humanitec Dev Container",
+	"image": "mcr.microsoft.com/devcontainers/base:jammy",
+	"features": {
+        "ghcr.io/devcontainers/features/terraform:1": {
+            "installTerraformDocs": true
+        }
+    },
+	"postCreateCommand": "bash .devcontainer/installMoreTools.sh",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"redhat.vscode-yaml",
+				"humanitec.humanitec"
+			],
+			"settings": {
+				"yaml.schemas": {
+					"https://raw.githubusercontent.com/score-spec/spec/main/score-v1b1.json": "score.yaml"
+				}
+			}
+		}
+	}
+}

--- a/.devcontainer/installMoreTools.sh
+++ b/.devcontainer/installMoreTools.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+mkdir install-more-tools
+cd install-more-tools
+
+HUMCTL_VERSION=$(curl -sL https://api.github.com/repos/humanitec/cli/releases/latest | jq -r .tag_name)
+curl -fLO https://github.com/humanitec/cli/releases/download/${HUMCTL_VERSION}/cli_${HUMCTL_VERSION:1}_linux_amd64.tar.gz
+tar -xvf cli_${HUMCTL_VERSION:1}_linux_amd64.tar.gz
+chmod +x humctl
+sudo mv humctl /usr/local/bin/humctl
+
+cd ..
+rm -rf install-more-tools

--- a/examples/mongodb/README.md
+++ b/examples/mongodb/README.md
@@ -68,10 +68,12 @@ resources:
 
 This Score file when deployed to Humanitec will provision the `mongodb` database and inject the outputs in the associated environment variable.
 
-Here is how to deploy this Score file, for example to the `hum-rp-mongodb-example` Application and `development` Environment:
+Here is how to deploy this Score file, for example to the `mongodb-example` Application and `development` Environment:
 ```bash
+humctl create app mongodb-example
+
 humctl score deploy \
     -f score.yaml \
-    --app hum-rp-mongodb-example \
+    --app mongodb-example \
     --env development
 ```

--- a/examples/mongodb/README.md
+++ b/examples/mongodb/README.md
@@ -26,14 +26,12 @@ This example configures a [mongodb](https://developer.humanitec.com/platform-orc
 
 | Name | Type |
 |------|------|
-| [humanitec_application.example](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/application) | resource |
 | [humanitec_resource_definition_criteria.mongodb_basic](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| name | Name of the example application | `string` | `"hum-rp-mongodb-example"` | no |
 | prefix | Prefix of the created resources | `string` | `"hum-rp-mongodb-ex-"` | no |
 <!-- END_TF_DOCS -->
 

--- a/examples/mongodb/main.tf
+++ b/examples/mongodb/main.tf
@@ -1,10 +1,3 @@
-resource "humanitec_application" "example" {
-  id   = var.name
-  name = var.name
-}
-
-# mysql resource definition
-
 module "mongodb_basic" {
   source = "../../humanitec-resource-defs/mongodb/basic"
 
@@ -13,7 +6,6 @@ module "mongodb_basic" {
 
 resource "humanitec_resource_definition_criteria" "mongodb_basic" {
   resource_definition_id = module.mongodb_basic.id
-  app_id                 = humanitec_application.example.id
   class                  = "default"
   force_delete           = true
 }

--- a/examples/mongodb/terraform.tfvars.example
+++ b/examples/mongodb/terraform.tfvars.example
@@ -1,6 +1,2 @@
-
-# Name of the example application
-name = "hum-rp-mongodb-example"
-
 # Prefix of the created resources
 prefix = "hum-rp-mongodb-ex-"

--- a/examples/mongodb/terraform.tfvars.example
+++ b/examples/mongodb/terraform.tfvars.example
@@ -1,2 +1,3 @@
+
 # Prefix of the created resources
 prefix = "hum-rp-mongodb-ex-"

--- a/examples/mongodb/variables.tf
+++ b/examples/mongodb/variables.tf
@@ -1,9 +1,3 @@
-variable "name" {
-  description = "Name of the example application"
-  type        = string
-  default     = "hum-rp-mongodb-example"
-}
-
 variable "prefix" {
   description = "Prefix of the created resources"
   type        = string

--- a/examples/mysql/README.md
+++ b/examples/mysql/README.md
@@ -26,14 +26,12 @@ This example configures a [mysql](https://developer.humanitec.com/platform-orche
 
 | Name | Type |
 |------|------|
-| [humanitec_application.example](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/application) | resource |
 | [humanitec_resource_definition_criteria.mysql_basic](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| name | Name of the example application | `string` | `"hum-rp-mysql-example"` | no |
 | prefix | Prefix of the created resources | `string` | `"hum-rp-mysql-ex-"` | no |
 <!-- END_TF_DOCS -->
 

--- a/examples/mysql/README.md
+++ b/examples/mysql/README.md
@@ -68,10 +68,12 @@ resources:
 
 This Score file when deployed to Humanitec will provision the `mysql` database and inject the outputs in the associated environment variable.
 
-Here is how to deploy this Score file, for example to the `hum-rp-mysql-example` Application and `development` Environment:
+Here is how to deploy this Score file, for example to the `mysql-example` Application and `development` Environment:
 ```bash
+humctl create app mysql-example
+
 humctl score deploy \
     -f score.yaml \
-    --app hum-rp-mysql-example \
+    --app mysql-example \
     --env development
 ```

--- a/examples/mysql/main.tf
+++ b/examples/mysql/main.tf
@@ -1,10 +1,3 @@
-resource "humanitec_application" "example" {
-  id   = var.name
-  name = var.name
-}
-
-# mysql resource definition
-
 module "mysql_basic" {
   source = "../../humanitec-resource-defs/mysql/basic"
 
@@ -13,7 +6,6 @@ module "mysql_basic" {
 
 resource "humanitec_resource_definition_criteria" "mysql_basic" {
   resource_definition_id = module.mysql_basic.id
-  app_id                 = humanitec_application.example.id
   class                  = "default"
   force_delete           = true
 }

--- a/examples/mysql/terraform.tfvars.example
+++ b/examples/mysql/terraform.tfvars.example
@@ -1,2 +1,3 @@
+
 # Prefix of the created resources
 prefix = "hum-rp-mysql-ex-"

--- a/examples/mysql/terraform.tfvars.example
+++ b/examples/mysql/terraform.tfvars.example
@@ -1,6 +1,2 @@
-
-# Name of the example application
-name = "hum-rp-mysql-example"
-
 # Prefix of the created resources
 prefix = "hum-rp-mysql-ex-"

--- a/examples/mysql/variables.tf
+++ b/examples/mysql/variables.tf
@@ -1,9 +1,3 @@
-variable "name" {
-  description = "Name of the example application"
-  type        = string
-  default     = "hum-rp-mysql-example"
-}
-
 variable "prefix" {
   description = "Prefix of the created resources"
   type        = string

--- a/examples/postgres/README.md
+++ b/examples/postgres/README.md
@@ -26,14 +26,12 @@ This example configures a [postgres](https://developer.humanitec.com/platform-or
 
 | Name | Type |
 |------|------|
-| [humanitec_application.example](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/application) | resource |
 | [humanitec_resource_definition_criteria.postgres_basic](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| name | Name of the example application | `string` | `"hum-rp-postgres-example"` | no |
 | prefix | Prefix of the created resources | `string` | `"hum-rp-postgres-ex-"` | no |
 <!-- END_TF_DOCS -->
 

--- a/examples/postgres/README.md
+++ b/examples/postgres/README.md
@@ -68,10 +68,12 @@ resources:
 
 This Score file when deployed to Humanitec will provision the `postgres` database and inject the outputs in the associated environment variable.
 
-Here is how to deploy this Score file, for example to the `hum-rp-postgres-example` Application and `development` Environment:
+Here is how to deploy this Score file, for example to the `postgres-example` Application and `development` Environment:
 ```bash
+humctl create app postgres-example
+
 humctl score deploy \
     -f score.yaml \
-    --app hum-rp-postgres-example \
+    --app postgres-example \
     --env development
 ```

--- a/examples/postgres/main.tf
+++ b/examples/postgres/main.tf
@@ -1,10 +1,3 @@
-resource "humanitec_application" "example" {
-  id   = var.name
-  name = var.name
-}
-
-# postgres resource definition
-
 module "postgres_basic" {
   source = "../../humanitec-resource-defs/postgres/basic"
 
@@ -13,7 +6,6 @@ module "postgres_basic" {
 
 resource "humanitec_resource_definition_criteria" "postgres_basic" {
   resource_definition_id = module.postgres_basic.id
-  app_id                 = humanitec_application.example.id
   class                  = "default"
   force_delete           = true
 }

--- a/examples/postgres/terraform.tfvars.example
+++ b/examples/postgres/terraform.tfvars.example
@@ -1,2 +1,3 @@
+
 # Prefix of the created resources
 prefix = "hum-rp-postgres-ex-"

--- a/examples/postgres/terraform.tfvars.example
+++ b/examples/postgres/terraform.tfvars.example
@@ -1,6 +1,2 @@
-
-# Name of the example application
-name = "hum-rp-postgres-example"
-
 # Prefix of the created resources
 prefix = "hum-rp-postgres-ex-"

--- a/examples/postgres/variables.tf
+++ b/examples/postgres/variables.tf
@@ -1,9 +1,3 @@
-variable "name" {
-  description = "Name of the example application"
-  type        = string
-  default     = "hum-rp-postgres-example"
-}
-
 variable "prefix" {
   description = "Prefix of the created resources"
   type        = string

--- a/examples/redis/README.md
+++ b/examples/redis/README.md
@@ -32,6 +32,7 @@ This example configures a [redis](https://developer.humanitec.com/platform-orche
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| name | Name of the example application | `string` | `"hum-rp-redis-example"` | no |
 | prefix | Prefix of the created resources | `string` | `"hum-rp-redis-ex-"` | no |
 <!-- END_TF_DOCS -->
 

--- a/examples/redis/README.md
+++ b/examples/redis/README.md
@@ -32,7 +32,6 @@ This example configures a [redis](https://developer.humanitec.com/platform-orche
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| name | Name of the example application | `string` | `"hum-rp-redis-example"` | no |
 | prefix | Prefix of the created resources | `string` | `"hum-rp-redis-ex-"` | no |
 <!-- END_TF_DOCS -->
 

--- a/examples/redis/README.md
+++ b/examples/redis/README.md
@@ -26,14 +26,12 @@ This example configures a [redis](https://developer.humanitec.com/platform-orche
 
 | Name | Type |
 |------|------|
-| [humanitec_application.example](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/application) | resource |
 | [humanitec_resource_definition_criteria.redis_basic](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| name | Name of the example application | `string` | `"hum-rp-redis-example"` | no |
 | prefix | Prefix of the created resources | `string` | `"hum-rp-redis-ex-"` | no |
 <!-- END_TF_DOCS -->
 

--- a/examples/redis/README.md
+++ b/examples/redis/README.md
@@ -69,10 +69,12 @@ resources:
 
 This Score file when deployed to Humanitec will provision the `redis` database and inject the outputs in the associated environment variable.
 
-Here is how to deploy this Score file, for example to the `hum-rp-redis-example` Application and `development` Environment:
+Here is how to deploy this Score file, for example to the `redis-example` Application and `development` Environment:
 ```bash
+humctl create app redis-example
+
 humctl score deploy \
     -f score.yaml \
-    --app hum-rp-redis-example \
+    --app redis-example \
     --env development
 ```

--- a/examples/redis/main.tf
+++ b/examples/redis/main.tf
@@ -1,10 +1,3 @@
-resource "humanitec_application" "example" {
-  id   = var.name
-  name = var.name
-}
-
-# redis resource definition
-
 module "redis_basic" {
   source = "../../humanitec-resource-defs/redis/basic"
 
@@ -13,7 +6,6 @@ module "redis_basic" {
 
 resource "humanitec_resource_definition_criteria" "redis_basic" {
   resource_definition_id = module.redis_basic.id
-  app_id                 = humanitec_application.example.id
   class                  = "default"
   force_delete           = true
 }

--- a/examples/redis/terraform.tfvars.example
+++ b/examples/redis/terraform.tfvars.example
@@ -1,6 +1,3 @@
 
-# Name of the example application
-name = "hum-rp-redis-example"
-
 # Prefix of the created resources
 prefix = "hum-rp-redis-ex-"

--- a/examples/redis/variables.tf
+++ b/examples/redis/variables.tf
@@ -1,9 +1,3 @@
-variable "name" {
-  description = "Name of the example application"
-  type        = string
-  default     = "hum-rp-redis-example"
-}
-
 variable "prefix" {
   description = "Prefix of the created resources"
   type        = string

--- a/humanitec-resource-defs/mongodb/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/mongodb/basic/terraform.tfvars.example
@@ -1,3 +1,2 @@
-
 # Prefix for all resources
 prefix = ""

--- a/humanitec-resource-defs/mongodb/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/mongodb/basic/terraform.tfvars.example
@@ -1,2 +1,3 @@
+
 # Prefix for all resources
 prefix = ""


### PR DESCRIPTION
This PR doesn't touch the TF modules per se, it's just updating the examples.

- Creating an App while deploying a resource pack is misleading and adding a lot of confusion.
- Furthermore, the matching criteria on the `app_id` was adding a bad experience for someone who starts with Humanitec: "should I redeploy for each App?"
- Based on MVPs we decide to remove this confusion
- Also, took the opportunity to add a `.devcontainer` with pre-installed `terraform`, `terraform-docs` and `humctl` to speedup usage and contributions with this repo