### PR TITLE
`postgres:17-alpine` + `securityContext`

### DIFF
--- a/humanitec-resource-defs/postgres/basic/main.tf
+++ b/humanitec-resource-defs/postgres/basic/main.tf
@@ -46,9 +46,10 @@ statefulset.yaml:
           labels:
             app: {{ .init.name }}
         spec:
+          automountServiceAccountToken: false
           containers:
             - name: {{ .init.name }}
-              image: postgres:15
+              image: postgres:17-alpine
               env:
                 - name: POSTGRES_USER
                   value: {{ .init.user | quote }}
@@ -69,6 +70,19 @@ statefulset.yaml:
               volumeMounts:
                 - name: {{ .init.name }}
                   mountPath: /var/lib/postgresql/data
+              securityContext:
+                runAsUser: 1000
+                runAsGroup: 1000
+                allowPrivilegeEscalation: false
+                privileged: false
+                capabilities:
+                  drop:
+                    - ALL
+          securityContext:
+            runAsNonRoot: true
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
       volumeClaimTemplates:
         - metadata:
             name: {{ .init.name }}
@@ -77,7 +91,7 @@ statefulset.yaml:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 10Gi
+                storage: 1Gi
 service.yaml:
   location: namespace
   data:


### PR DESCRIPTION
More security for the default `postgres` in-cluster res pack:
- `postgres:17-alpine`
- `securityContext` --> This is required for customers using Pod Security Standard (PSS/PSA) for example.
- `automountServiceAccountToken=false`

Not related to this, but also took the initiative to change `storage: 10Gi` to `1Gi` instead, `10Gi` was excessive according to me.

Tested with with `score-k8s`: https://github.com/score-spec/score-k8s/pull/38.

https://github.com/score-spec/sample-score-app successfully deployed in Humanitec with this new `postgres` res pack:
<img width="1082" alt="image" src="https://github.com/user-attachments/assets/3bcdb78b-809e-4bcc-ac3f-a1e74e8f91da">

```
NAME                                          READY   STATUS    RESTARTS        AGE
hello-world-777fd66989-g4jv7                  2/2     Running   1 (4m26s ago)   4m31s
postgres-modules-hello-world-externals-db-0   2/2     Running   0               5m7s
```